### PR TITLE
fix: update Gemini availability check to use gemini-2.5-flash

### DIFF
--- a/src/litemind/apis/providers/google/utils/check_availability.py
+++ b/src/litemind/apis/providers/google/utils/check_availability.py
@@ -43,7 +43,7 @@ def check_gemini_api_availability(client: "Client"):
     try:
         # Minimal call: generate a short response
         resp = client.models.generate_content(
-            model="models/gemini-2.0-flash",
+            model="models/gemini-2.5-flash",
             contents="Hello, What is your name? (short answer please)",
         )
 


### PR DESCRIPTION
## Summary

- Update the model used in `check_gemini_api_availability()` from `gemini-2.0-flash` to `gemini-2.5-flash`
- Google has removed the free tier quota for `gemini-2.0-flash` (RPM/TPM/RPD all 0), while `gemini-2.5-flash` still has an active free tier (RPM 5, TPM 250K, RPD 20)
- This was causing a `429 RESOURCE_EXHAUSTED` error during the availability check, incorrectly marking Gemini as unavailable

Fixes #12

## Test plan

- [x] Verify napari-chatgpt startup no longer shows 429 error for Gemini
- [x] Verify Gemini API is correctly detected as available with a valid free-tier API key