### PR TITLE
fix: handle Ollama -thinking model names and Anthropic empty text blocks

### DIFF
--- a/src/litemind/apis/providers/anthropic/tests/test_anthropic_utils.py
+++ b/src/litemind/apis/providers/anthropic/tests/test_anthropic_utils.py
@@ -1,0 +1,117 @@
+"""Unit tests for Anthropic message conversion and response processing.
+
+Tests cover the empty text block handling added to:
+- convert_messages_for_anthropic (skip empty text blocks)
+- process_response_from_anthropic (skip empty text blocks from API responses)
+"""
+
+from unittest.mock import MagicMock
+
+from litemind.agent.messages.message import Message
+from litemind.apis.providers.anthropic.utils.convert_messages import (
+    convert_messages_for_anthropic,
+)
+from litemind.apis.providers.anthropic.utils.process_response import (
+    process_response_from_anthropic,
+)
+from litemind.media.types.media_text import Text
+
+
+# =========================================================================
+# convert_messages_for_anthropic — empty text block tests
+# =========================================================================
+
+
+class TestConvertMessagesEmptyTextBlocks:
+    """Empty text blocks must be skipped to avoid Anthropic 400 errors."""
+
+    def test_empty_assistant_text_skipped(self):
+        """Assistant message with only whitespace text should not produce empty blocks."""
+        msg = Message(role="assistant")
+        msg.append_text("   ")  # whitespace only — becomes empty after rstrip
+        result = convert_messages_for_anthropic([msg])
+        # The message should be dropped or have no text content blocks:
+        for m in result:
+            if m["role"] == "assistant":
+                for block in m.get("content", []):
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        assert block["text"], "Empty text block should have been skipped"
+
+    def test_nonempty_text_preserved(self):
+        """Non-empty text blocks should still be included."""
+        msg = Message(role="user", text="Hello")
+        result = convert_messages_for_anthropic([msg])
+        assert len(result) == 1
+        content = result[0]["content"]
+        text_blocks = [b for b in content if isinstance(b, dict) and b.get("type") == "text"]
+        assert len(text_blocks) == 1
+        assert text_blocks[0]["text"] == "Hello"
+
+    def test_mixed_empty_and_nonempty(self):
+        """Only non-empty text blocks should survive conversion."""
+        msg = Message(role="assistant")
+        msg.append_text("")  # empty
+        msg.append_text("Valid text")
+        result = convert_messages_for_anthropic([msg])
+        for m in result:
+            if m["role"] == "assistant":
+                text_blocks = [
+                    b
+                    for b in m.get("content", [])
+                    if isinstance(b, dict) and b.get("type") == "text"
+                ]
+                assert all(b["text"] for b in text_blocks)
+                assert any("Valid text" in b["text"] for b in text_blocks)
+
+
+# =========================================================================
+# process_response_from_anthropic — empty text block tests
+# =========================================================================
+
+
+class TestProcessResponseEmptyTextBlocks:
+    """Empty text blocks from API responses must be skipped."""
+
+    def _make_response(self, content_blocks):
+        """Create a mock Anthropic response with given content blocks."""
+        resp = MagicMock()
+        resp.content = content_blocks
+        resp.stop_reason = "end_turn"
+        resp.usage = MagicMock()
+        resp.usage.input_tokens = 10
+        resp.usage.output_tokens = 5
+        resp.usage.cache_creation_input_tokens = 0
+        resp.usage.cache_read_input_tokens = 0
+        return resp
+
+    def _text_block(self, text):
+        block = MagicMock()
+        block.type = "text"
+        block.text = text
+        return block
+
+    def test_empty_text_block_skipped(self):
+        """Empty text blocks from the API should not produce text in the message."""
+        resp = self._make_response([self._text_block("")])
+        result = process_response_from_anthropic(resp)
+        text_blocks = [b for b in result.blocks if b.has_type(Text) and not b.is_thinking()]
+        assert len(text_blocks) == 0
+
+    def test_nonempty_text_block_preserved(self):
+        """Non-empty text blocks should still be processed."""
+        resp = self._make_response([self._text_block("Hello world")])
+        result = process_response_from_anthropic(resp)
+        text_blocks = [b for b in result.blocks if b.has_type(Text) and not b.is_thinking()]
+        assert len(text_blocks) == 1
+        assert "Hello world" in text_blocks[0].get_content()
+
+    def test_mixed_empty_and_nonempty_response(self):
+        """Only non-empty text blocks should appear in the processed message."""
+        resp = self._make_response([
+            self._text_block(""),
+            self._text_block("Valid response"),
+        ])
+        result = process_response_from_anthropic(resp)
+        text_blocks = [b for b in result.blocks if b.has_type(Text) and not b.is_thinking()]
+        assert len(text_blocks) == 1
+        assert "Valid response" in text_blocks[0].get_content()

--- a/src/litemind/apis/providers/anthropic/utils/convert_messages.py
+++ b/src/litemind/apis/providers/anthropic/utils/convert_messages.py
@@ -59,6 +59,11 @@ def convert_messages_for_anthropic(
                     # remove trailing whitespace as it is not allowed by Anthropic!
                     text = text.rstrip()
 
+                # Skip empty text blocks — the API rejects them with
+                # "text content blocks must be non-empty".
+                if not text:
+                    continue
+
                 # Create text block
                 text_block = {"type": "text", "text": text}
 

--- a/src/litemind/apis/providers/anthropic/utils/process_response.py
+++ b/src/litemind/apis/providers/anthropic/utils/process_response.py
@@ -56,6 +56,14 @@ def process_response_from_anthropic(
         if block.type == "text":
             # Handle regular text blocks (may include citations)
             text = block.text
+
+            # Skip empty text blocks — Anthropic may return these alongside
+            # tool-use blocks.  Storing them would later cause a 400 error
+            # ("text content blocks must be non-empty") when the conversation
+            # history is sent back to the API.
+            if not text:
+                continue
+
             processed_response.append_text(text)
             text_content += text
 

--- a/src/litemind/apis/providers/ollama/ollama_api.py
+++ b/src/litemind/apis/providers/ollama/ollama_api.py
@@ -662,9 +662,14 @@ class OllamaApi(DefaultApi):
         use_native_thinking = False
 
         if use_thinking:
-            # Remove the -thinking postfix from the model name:
+            # Remove the -thinking postfix from the model name, but only
+            # when the base model actually exists in Ollama.  Some models
+            # (e.g. qwen3:30b-thinking) use "-thinking" as part of their
+            # real Ollama registry name — stripping it would cause a 404.
             if model_name.endswith("-thinking"):
-                model_name = model_name[:-9]
+                base_model_name = model_name[:-9]
+                if base_model_name in self._model_list:
+                    model_name = base_model_name
 
             # Check if the model supports native think parameter:
             if self._has_native_thinking(model_name):

--- a/src/litemind/apis/providers/ollama/tests/test_ollama_utils.py
+++ b/src/litemind/apis/providers/ollama/tests/test_ollama_utils.py
@@ -496,3 +496,46 @@ class TestProcessResponseEdgeCases:
 
         action_blocks = [b for b in result.blocks if b.has_type(Action)]
         assert len(action_blocks) == 1
+
+
+# =========================================================================
+# _get_ollama_models_list tests
+# =========================================================================
+
+
+class TestGetOllamaModelsList:
+    """Tests for _get_ollama_models_list thinking-variant generation."""
+
+    def _make_client(self, model_names):
+        """Create a mock Ollama client with the given model names."""
+        client = MagicMock()
+        models = []
+        for name in model_names:
+            m = MagicMock()
+            m.model = name
+            m.size = 1000
+            models.append(m)
+        client.list.return_value.models = models
+        return client
+
+    def test_thinking_variants_added(self):
+        """Each regular model should get a -thinking variant."""
+        from litemind.apis.providers.ollama.utils.list_models import (
+            _get_ollama_models_list,
+        )
+
+        client = self._make_client(["llama3:8b"])
+        result = _get_ollama_models_list(client)
+        assert "llama3:8b" in result
+        assert "llama3:8b-thinking" in result
+
+    def test_no_double_thinking_suffix(self):
+        """Models already ending in -thinking should not get a second suffix."""
+        from litemind.apis.providers.ollama.utils.list_models import (
+            _get_ollama_models_list,
+        )
+
+        client = self._make_client(["qwen3:30b-thinking"])
+        result = _get_ollama_models_list(client)
+        assert "qwen3:30b-thinking" in result
+        assert "qwen3:30b-thinking-thinking" not in result

--- a/src/litemind/apis/providers/ollama/utils/list_models.py
+++ b/src/litemind/apis/providers/ollama/utils/list_models.py
@@ -41,11 +41,14 @@ def _get_ollama_models_list(client) -> List[str]:
     # Ensure it is a list:
     model_list = list(model_list)
 
-    # For each model, insert a thinking version with a '-thinking' suffix to the same list:
+    # For each model, insert a thinking version with a '-thinking' suffix to the same list.
+    # Skip models whose name already ends in '-thinking' to avoid
+    # nonsensical double-suffixed entries like 'qwen3:30b-thinking-thinking'.
     model_list_with_thinking = []
     for model in model_list:
         model_list_with_thinking.append(model)
-        model_list_with_thinking.append(f"{model}-thinking")
+        if not model.endswith("-thinking"):
+            model_list_with_thinking.append(f"{model}-thinking")
     model_list = model_list_with_thinking
 
     # Return the list of models:


### PR DESCRIPTION
## Summary

- **Ollama -thinking suffix handling (Fixes #14):** Only strip the `-thinking` suffix when the base model actually exists in Ollama. Models like `qwen3:30b-thinking` whose real registry name ends in `-thinking` were getting a 404 because litemind unconditionally stripped the suffix. Also prevents double-suffixed entries (`model-thinking-thinking`) in the model list.
- **Anthropic empty text blocks:** Skip empty text blocks in both message conversion and response processing. Anthropic may return empty text blocks alongside tool-use blocks, and sending them back causes a 400 error ("text content blocks must be non-empty").

## Test plan

- [x] Unit tests for `_get_ollama_models_list` — verifies `-thinking` variants are added and double-suffixing is prevented (2 new tests)
- [x] Unit tests for Anthropic `convert_messages` and `process_response` — verifies empty text blocks are skipped (6 new tests)
- [x] All 36 provider unit tests pass
- [ ] Verify Ollama model whose name ends in `-thinking` (e.g. `qwen3:30b-thinking`) works without 404
- [ ] Verify synthetic `-thinking` suffix still works for regular models (e.g. `llama3:8b-thinking`)
- [ ] Verify Anthropic multi-turn tool-use conversations no longer fail with empty text block errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)